### PR TITLE
Use template for the Abstract Segment Tree implementation

### DIFF
--- a/RangeQuery/SegmentTreeAbstract.h
+++ b/RangeQuery/SegmentTreeAbstract.h
@@ -1,26 +1,19 @@
 #include <vector>
 #include <limits>
+#include <functional>
 
-struct Segment {
-
-};
-
-Segment combine(Segment a, Segment b) {
-    return a;
-}
-
+template<typename Segment>
 class SegmentTree {
 public:
-	SegmentTree(int count) {
+	SegmentTree(int count, std::function<Segment(Segment, Segment)> combine) : combine{combine} {
 		n = count;
 		data.resize(2 * n);
 	}
 
-	SegmentTree(std::vector<Segment> const &values) {
+	SegmentTree(std::vector<Segment> const &values, std::function<Segment(Segment, Segment)> combine) : combine{combine} {
 		n = values.size();
 		data.resize(2 * n);
-        for (int idx = 0; idx < n; idx++)
-            data[idx + n] = values[idx];
+    std::copy(values.begin(), values.end(), &data[0] + n);
 		for (int idx = n - 1; idx > 0; idx--)
 			data[idx] = combine(data[idx * 2], data[idx * 2 + 1]);
 	}
@@ -36,9 +29,9 @@ public:
 	}
 
 	Segment minimum(int left, int right) { // interval [left, right)
-		Segment ret_l, ret_r;
 		left += n;
 		right += n;
+		Segment ret_l = data[left++], ret_r = data[--right];
 
 		while (left < right) {
 			if (left & 1) ret_l = combine(ret_l, data[left++]);
@@ -52,4 +45,5 @@ public:
 private:
 	int n;
 	std::vector<Segment> data;
+	std::function<Segment(Segment, Segment)> combine;
 };

--- a/RangeQuery/SegmentTreeAbstract.h
+++ b/RangeQuery/SegmentTreeAbstract.h
@@ -5,45 +5,47 @@
 template<typename Segment>
 class SegmentTree {
 public:
-	SegmentTree(int count, std::function<Segment(Segment, Segment)> combine) : combine{combine} {
-		n = count;
-		data.resize(2 * n);
-	}
+    using CombineFkt = std::function<Segment(Segment, Segment)>;
 
-	SegmentTree(std::vector<Segment> const &values, std::function<Segment(Segment, Segment)> combine) : combine{combine} {
-		n = values.size();
-		data.resize(2 * n);
-    std::copy(values.begin(), values.end(), &data[0] + n);
-		for (int idx = n - 1; idx > 0; idx--)
-			data[idx] = combine(data[idx * 2], data[idx * 2 + 1]);
-	}
+    SegmentTree(int count, CombineFkt combine) : combine{combine} {
+        n = count;
+        data.resize(2 * n);
+    }
 
-	void update(int idx, Segment value) {
-		idx += n;
-		data[idx] = value;
+    SegmentTree(std::vector<Segment> const &values, CombineFkt combine) : combine{combine} {
+        n = values.size();
+        data.resize(2 * n);
+        std::copy(values.begin(), values.end(), &data[n]);
+        for (int idx = n - 1; idx > 0; idx--)
+            data[idx] = combine(data[idx * 2], data[idx * 2 + 1]);
+    }
 
-		while (idx > 1) {
-			idx /= 2;
-			data[idx] = combine(data[2 * idx], data[2 * idx + 1]);
-		}
-	}
+    void update(int idx, Segment value) {
+        idx += n;
+        data[idx] = value;
 
-	Segment minimum(int left, int right) { // interval [left, right)
-		left += n;
-		right += n;
-		Segment ret_l = data[left++], ret_r = data[--right];
+        while (idx > 1) {
+            idx /= 2;
+            data[idx] = combine(data[2 * idx], data[2 * idx + 1]);
+        }
+    }
 
-		while (left < right) {
-			if (left & 1) ret_l = combine(ret_l, data[left++]);
-			if (right & 1) ret_r = combine(data[--right], ret_r);
-			left >>= 1;
-			right >>= 1;
-		}
-		return combine(ret_l, ret_r);
-	}
+    Segment minimum(int left, int right) { // interval [left, right)
+        Segment ret_l{}, ret_r{};
+        left += n;
+        right += n;
+
+        while (left < right) {
+            if (left & 1) ret_l = combine(ret_l, data[left++]);
+            if (right & 1) ret_r = combine(data[--right], ret_r);
+            left >>= 1;
+            right >>= 1;
+        }
+        return combine(ret_l, ret_r);
+    }
 
 private:
-	int n;
-	std::vector<Segment> data;
-	std::function<Segment(Segment, Segment)> combine;
+    int n;
+    std::vector<Segment> data;
+    CombineFkt combine;
 };

--- a/RangeQuery/SegmentTreeAbstract.h
+++ b/RangeQuery/SegmentTreeAbstract.h
@@ -31,9 +31,13 @@ public:
     }
 
     Segment minimum(int left, int right) { // interval [left, right)
-        Segment ret_l{}, ret_r{};
         left += n;
         right += n;
+
+        if (left + 1 == right)
+            return data[left];
+
+        Segment ret_l = data[left++], ret_r = data[--right];
 
         while (left < right) {
             if (left & 1) ret_l = combine(ret_l, data[left++]);


### PR DESCRIPTION
- Templatise the class for easier use with multiple types and pass the combine function as a paramater.
- Initialise the ret_l  and ret_r before combinining so that the value is initialised and doesn't return an incorrect value.