### PR TITLE
Fix bug in SparseTable.h minimum func

### DIFF
--- a/RangeQuery/SparseTable.h
+++ b/RangeQuery/SparseTable.h
@@ -24,7 +24,7 @@ public:
     {
         int log = log_table[r - l];
         return std::min(sparse_table[log][l],
-                        sparse_table[log][r - (1 << log)]);
+                        sparse_table[log][r - (1 << log) + 1]);
     }
 
 private:

--- a/RangeQuery/SparseTable.h
+++ b/RangeQuery/SparseTable.h
@@ -3,7 +3,7 @@
 class SparseTable
 {
 public:
-    SparseTable(std::vector<int> v)
+    SparseTable(const std::vector<int> &v)
     {
         log_table.assign(v.size() + 1, 0);
         for (auto i = 2UL; i < log_table.size(); i++)


### PR DESCRIPTION
Otherwise, the value at the 'r' index position is not accounted for.